### PR TITLE
Fixed package.json, made only conversation selectable

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,5 +14,5 @@
     "gulp-minify-css": "^1.0.0",
     "gulp-tap": "^0.1.3",
     "gulp-uglify": "^1.1.0"
-  },
+  }
 }

--- a/server/src/fb.css
+++ b/server/src/fb.css
@@ -1,3 +1,11 @@
+body {
+  -webkit-user-select: none;
+}
+
+.uiScrollableAreaContent {
+  -webkit-user-select: text;
+}
+
 #pagelet_bluebar, #pagelet_dock, #pagelet_sidebar, #rightCol, #pageFooter {
     display: none
 }


### PR DESCRIPTION
Hi, I couldn't build the app to test this (xcode noob) but I have added CSS which - in the browser version of messenger - makes only the comments section selectable. Let me know if it doesn't work.

Basically, I figured this looked a bit ugly and makes it feel non-native:

![image](https://cloud.githubusercontent.com/assets/6671020/6981402/acd05682-d9f8-11e4-83d1-5576e02ed969.png)

RE building the app I get this error 

![image](https://cloud.githubusercontent.com/assets/6671020/6981408/c72acf80-d9f8-11e4-949d-7568157b9743.png)

but I've never developed mac apps so *shrugs*..
