### PR TITLE
Fix text input focusing on keypress

### DIFF
--- a/server/src/fb.js
+++ b/server/src/fb.js
@@ -63,11 +63,12 @@ function init() {
 	}, 3000);
 
 	document.body.onkeypress=function(e) {
-		if (!document.querySelector('._209g._2vxa span span') && !e.metaKey) {
+		if (!document.querySelector('._54-z:focus') && !e.metaKey) {
 			var char = event.which || event.keyCode;
 
 			var textEvent = document.createEvent('TextEvent');
 			textEvent.initTextEvent('textInput', true, true, null, String.fromCharCode(char), 9, "en-US");
+			document.querySelector('._54-z').focus();
 			document.querySelector('._209g._2vxa').dispatchEvent(textEvent);
 
 			return false;

--- a/server/src/fb.js
+++ b/server/src/fb.js
@@ -66,9 +66,18 @@ function init() {
 		if (!document.querySelector('._54-z:focus') && !e.metaKey) {
 			var char = event.which || event.keyCode;
 
+			// Focus the input at the end of any current text.
+			var el = document.querySelector('._54-z');
+			var range = document.createRange();
+			var sel = window.getSelection();
+			range.setStart(el, 1);
+			range.collapse(true);
+			sel.removeAllRanges();
+			sel.addRange(range);
+
+			// Trigger the captured key press.
 			var textEvent = document.createEvent('TextEvent');
 			textEvent.initTextEvent('textInput', true, true, null, String.fromCharCode(char), 9, "en-US");
-			document.querySelector('._54-z').focus();
 			document.querySelector('._209g._2vxa').dispatchEvent(textEvent);
 
 			return false;


### PR DESCRIPTION
Previous implementation fired the key event on the input successfully,
so the letter you pressed made it into the input - but it didn't then
focus the input, so you couldn't keep typing.

It also only checked that the spans containing text didn't exist -
meaning once there's a single character in the input, the code stops
running. Instead, check if the input's focused, and focus after firing
the event.