### PR TITLE
Add image pasting functionality

### DIFF
--- a/Goofy/Base.lproj/MainMenu.xib
+++ b/Goofy/Base.lproj/MainMenu.xib
@@ -59,11 +59,7 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
-                            <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW">
-                                <connections>
-                                    <action selector="preferences:" target="XE1-by-mZK" id="5EP-3F-9Vz"/>
-                                </connections>
-                            </menuItem>
+                            <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
                             <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
                             <menuItem title="Services" id="NMo-om-nkz">
                                 <modifierMask key="keyEquivalentModifierMask"/>
@@ -152,7 +148,7 @@
                             </menuItem>
                             <menuItem title="Paste" keyEquivalent="v" id="tKE-Dj-Ehn">
                                 <connections>
-                                    <action selector="paste:" target="-1" id="HOh-W5-HNv"/>
+                                    <action selector="handlePaste" target="Voe-Tx-rLC" id="EYy-An-Uvn"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Paste and Match Style" keyEquivalent="V" id="lNI-nl-Wf9">
@@ -359,19 +355,11 @@
                                     <action selector="performZoom:" target="-1" id="DIl-cC-cCs"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Main Window" id="kL3-T3-sdc">
-                                <modifierMask key="keyEquivalentModifierMask"/>
+                            <menuItem title="Main Window" keyEquivalent="0" id="kL3-T3-sdc">
                                 <connections>
                                     <action selector="reopenWindow:" target="Voe-Tx-rLC" id="Rpk-6v-yT3"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Toggle Full Screen" keyEquivalent="f" id="WDN-WB-Gf5">
-                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
-                                <connections>
-                                    <action selector="fullscreen:" target="XE1-by-mZK" id="Dbb-ar-PzZ"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem isSeparatorItem="YES" id="dwq-fA-fPF"/>
                             <menuItem title="Next conversation" tag="1" keyEquivalent="]" id="TCm-7h-nwy">
                                 <connections>
                                     <action selector="gotoConversation:" target="XE1-by-mZK" id="nHl-8O-kRk"/>
@@ -381,63 +369,6 @@
                                 <connections>
                                     <action selector="gotoConversation:" target="XE1-by-mZK" id="jfJ-gk-A3e"/>
                                 </connections>
-                            </menuItem>
-                            <menuItem title="Recent conversations" id="88k-oL-2hk">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Recent conversations" id="sLe-0p-RnN">
-                                    <items>
-                                        <menuItem title="1st conversation" tag="1" keyEquivalent="1" id="hUx-33-dKc">
-                                            <connections>
-                                                <action selector="gotoConversationAtIndex:" target="XE1-by-mZK" id="pM4-Ao-G7e"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="2nd conversation" tag="2" keyEquivalent="2" id="3zV-NI-7u3">
-                                            <connections>
-                                                <action selector="gotoConversationAtIndex:" target="XE1-by-mZK" id="XIU-Q7-yo1"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="3rd conversation" tag="3" keyEquivalent="3" id="2nX-ho-iYX">
-                                            <connections>
-                                                <action selector="gotoConversationAtIndex:" target="XE1-by-mZK" id="2th-LO-GGb"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="4th conversation" tag="4" keyEquivalent="4" id="azw-8x-pe6">
-                                            <connections>
-                                                <action selector="gotoConversationAtIndex:" target="XE1-by-mZK" id="LAq-iU-5cF"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="5th conversation" tag="5" keyEquivalent="5" id="3TY-M4-sSG">
-                                            <connections>
-                                                <action selector="gotoConversationAtIndex:" target="XE1-by-mZK" id="vxn-tv-Q1W"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="6th conversation" tag="6" keyEquivalent="6" id="8IY-lf-4Pt">
-                                            <connections>
-                                                <action selector="gotoConversationAtIndex:" target="XE1-by-mZK" id="UCJ-Ec-uCn"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="7th conversation" tag="7" keyEquivalent="7" id="9z4-Ht-UXc">
-                                            <connections>
-                                                <action selector="gotoConversationAtIndex:" target="XE1-by-mZK" id="RgU-xg-GPi"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="8th conversation" tag="8" keyEquivalent="8" id="3fG-it-yzs">
-                                            <connections>
-                                                <action selector="gotoConversationAtIndex:" target="XE1-by-mZK" id="0Z8-ce-QKI"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="9th conversation" tag="10" keyEquivalent="9" id="TH5-Rg-12I">
-                                            <connections>
-                                                <action selector="gotoConversationAtIndex:" target="XE1-by-mZK" id="gyq-mH-TzR"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="10th conversation" tag="10" keyEquivalent="0" id="ftF-M8-E2a">
-                                            <connections>
-                                                <action selector="gotoConversationAtIndex:" target="XE1-by-mZK" id="UFk-6L-MYZ"/>
-                                            </connections>
-                                        </menuItem>
-                                    </items>
-                                </menu>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
                             <menuItem title="Jump to latest conversation" id="tfP-aR-ouj">
@@ -482,7 +413,7 @@
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="706" height="467"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <view key="contentView" wantsLayer="YES" id="5iU-zi-Msx">
                 <rect key="frame" x="0.0" y="0.0" width="706" height="467"/>
                 <autoresizingMask key="autoresizingMask"/>

--- a/server/src/fb.js
+++ b/server/src/fb.js
@@ -306,15 +306,15 @@ function getPhotoUploadComponent() {
 
 // Unwrap the children from a React class instance.
 function getChildren(instance) {
-  var children = null;
-  if (instance._renderedComponent) {
-    children = getChildren(instance._renderedComponent);
-  } else if (instance._renderedChildren) {
-    children = instance._renderedChildren;
-  } else {
-    children = [];
-  }
-  return children;
+	var children = null;
+	if (instance._renderedComponent) {
+		children = getChildren(instance._renderedComponent);
+	} else if (instance._renderedChildren) {
+		children = instance._renderedChildren;
+	} else {
+		children = [];
+	}
+	return children;
 }
 
 function __triggerKeyboardEvent(el, keyCode, meta) {

--- a/server/src/fb.js
+++ b/server/src/fb.js
@@ -5,6 +5,15 @@ var lastNotificationTime;
 for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d])};b.__SV=1.2;a=f.createElement("script");a.type="text/javascript";a.async=!0;a.src="//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=f.getElementsByTagName("script")[0];e.parentNode.insertBefore(a,e)}})(document,window.mixpanel||[]);
 mixpanel.init("2245181dbc803998dedc5b07d840e672");
 
+// Get React's runtime using the dev tool hook.
+Object.defineProperty(window, '__REACT_DEVTOOLS_GLOBAL_HOOK__', {
+	value: {
+		inject: function(runtime) {this._reactRuntime = runtime; },
+		getSelectedInstance: null,
+		Overlay: null
+	}
+});
+
 var emoticonMapping = {
 	"emoticon_smile"		:"😃",
 	"emoticon_frown"		:"😦",
@@ -245,6 +254,67 @@ function replyToNotification(userid, answer) {
 
 		__triggerKeyboardEvent(document.querySelector('._209g._2vxa'),13,true);
 	},50);
+}
+
+// Handle pasted image data forwarded from the wrapper app.
+function pasteImage(base64Data) {
+	var blob = b64toBlob(base64Data, 'image/png');
+	var uploader = getPhotoUploadComponent();
+	uploader._instance.uploadFile(blob);
+}
+
+// Convert base64 encoded data to a Blob.
+function b64toBlob(b64Data, contentType, sliceSize) {
+    contentType = contentType || '';
+    sliceSize = sliceSize || 512;
+
+    var byteCharacters = atob(b64Data);
+    var byteArrays = [];
+
+    for (var offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+        var slice = byteCharacters.slice(offset, offset + sliceSize);
+
+        var byteNumbers = new Array(slice.length);
+        for (var i = 0; i < slice.length; i++) {
+            byteNumbers[i] = slice.charCodeAt(i);
+        }
+
+        var byteArray = new Uint8Array(byteNumbers);
+
+        byteArrays.push(byteArray);
+    }
+
+    var blob = new Blob(byteArrays, {type: contentType});
+    return blob;
+}
+
+// Find the instance of the photo upload class from the React component tree.
+function getPhotoUploadComponent() {
+	var id = '.0.1.$1.0.1.$0.1.0.$1.0.1.0';
+	var idComponents = id.split('.');
+	var children = __REACT_DEVTOOLS_GLOBAL_HOOK__._reactRuntime.Mount._instancesByReactRootID;
+	var component;
+
+	for (var i = 1; i < idComponents.length; i++) {
+		var rootId = '.' + idComponents[i];
+		component = children[rootId];
+		children = getChildren(component);
+	}
+
+	return component;
+}
+
+// Unwrap the children from a React class instance.
+function getChildren(instance) {
+  var children = null;
+  if (instance._renderedComponent) {
+    children = getChildren(instance._renderedComponent);
+  } else if (instance._renderedChildren) {
+    children = instance._renderedChildren;
+  } else {
+    children = [];
+  }
+  return children;
 }
 
 function __triggerKeyboardEvent(el, keyCode, meta) {

--- a/server/src/fb.js
+++ b/server/src/fb.js
@@ -290,7 +290,7 @@ function b64toBlob(b64Data, contentType, sliceSize) {
 
 // Find the instance of the photo upload class from the React component tree.
 function getPhotoUploadComponent() {
-	var id = '.0.1.$1.0.1.$0.1.0.$1.0.1.0';
+	var id = '.0.1.$1.0.1.$0.1.0.1.1.0';
 	var idComponents = id.split('.');
 	var children = __REACT_DEVTOOLS_GLOBAL_HOOK__._reactRuntime.Mount._instancesByReactRootID;
 	var component;


### PR DESCRIPTION
Safari doesn't implement DataTransfer.items, so there's no way to
extract image data (i.e. a screenshot copied to the clipboard) in
Javascript. You can get copied files, but not data. Capture the paste
in Swift and then forward on the image data to the webview.

Currently supports pasting image data (and forwards on text), but
pasting an image file doesn't work — when you try to paste a file it sends the icon instead. My Swift-fu isn't that great, so someone else will need to fix that.