### PR TITLE
Fix Messenger.com opening in browser on launch

### DIFF
--- a/Goofy/AppDelegate.swift
+++ b/Goofy/AppDelegate.swift
@@ -155,8 +155,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKUIDe
         
         if let url = navigationAction.request.URL {
             var inApp = url.host!.hasSuffix("messenger.com") && !url.path!.hasPrefix("/l.php");
+            var isLogin = url.host!.hasSuffix("facebook.com") && (url.path!.hasPrefix("/login") || url.path!.hasPrefix("/checkpoint"));
             
-            if inApp {
+            if inApp || isLogin {
                 decisionHandler(.Allow)
             } else {
                 NSWorkspace.sharedWorkspace().openURL(navigationAction.request.URL!)

--- a/Goofy/AppDelegate.swift
+++ b/Goofy/AppDelegate.swift
@@ -153,19 +153,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKUIDe
     
     func webView(webView: WKWebView, decidePolicyForNavigationAction navigationAction: WKNavigationAction, decisionHandler: ((WKNavigationActionPolicy) -> Void)) {
         
-        var inAppURLs : Array = ["messenger.com/login","messenger.com/t"]
-        
-        if let nav = navigationAction.request.URL!.absoluteString {
-            let inApp = inAppURLs.reduce(false, combine: { result, url in result || nav.rangeOfString(url) != nil })
+        if let url = navigationAction.request.URL {
+            var inApp = url.host!.hasSuffix("messenger.com") && !url.path!.hasPrefix("/l.php");
             
-            if inApp  {
+            if inApp {
                 decisionHandler(.Allow)
             } else {
                 NSWorkspace.sharedWorkspace().openURL(navigationAction.request.URL!)
                 decisionHandler(.Cancel)
             }
         }
-                
     }
     
     func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {


### PR DESCRIPTION
Messenger.com updated to navigate to "https://www.messenger.com/" as part of loading, which wasn't allowed in the list of whitelisted URLs. I've switched to a blacklist instead — the only thing I've seen that shouldn't open in app is the external link page (`l.php`).

I've also added support for logging in with verifications enabled.