### PR TITLE
fixes #112

### DIFF
--- a/Goofy/AppDelegate.swift
+++ b/Goofy/AppDelegate.swift
@@ -143,8 +143,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKUIDe
             toolbarTrenner.view?.layer?.backgroundColor = NSColor(white: 0.9, alpha: 1.0).CGColor
             
             
-            toolbarSpacing.minSize = NSSize(width: 157, height: 100)
-            toolbarSpacing.maxSize = NSSize(width: 157, height: 100)
+            toolbarSpacing.minSize = NSSize(width: 197, height: 100)
+            toolbarSpacing.maxSize = NSSize(width: 197, height: 100)
             toolbarSpacing.view = NSView(frame: CGRectMake(0, 0, 157, 100))
         } else {
             toolbarTrenner.view?.layer?.backgroundColor = NSColor(white: 1.0, alpha: 0.0).CGColor

--- a/server/src/fb.css
+++ b/server/src/fb.css
@@ -28,8 +28,8 @@ html {
 }
 
 ._1enh {
-    min-width: 280px;
-    width: 280px !important;
+    min-width: 320px;
+    width: 320px !important;
 }
 
 ._5irm {


### PR DESCRIPTION
Wasn't showing context menu in chat summary because default width of the chat summary is now 320px wide (previous width was 280px wide)

Fix was to update to the new width.