### PR TITLE
fixes #112

### DIFF
--- a/Goofy/AppDelegate.swift
+++ b/Goofy/AppDelegate.swift
@@ -143,8 +143,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKUIDe
             toolbarTrenner.view?.layer?.backgroundColor = NSColor(white: 0.9, alpha: 1.0).CGColor
             
             
-            toolbarSpacing.minSize = NSSize(width: 157, height: 100)
-            toolbarSpacing.maxSize = NSSize(width: 157, height: 100)
+            toolbarSpacing.minSize = NSSize(width: 197, height: 100)
+            toolbarSpacing.maxSize = NSSize(width: 197, height: 100)
             toolbarSpacing.view = NSView(frame: CGRectMake(0, 0, 157, 100))
         } else {
             toolbarTrenner.view?.layer?.backgroundColor = NSColor(white: 1.0, alpha: 0.0).CGColor

--- a/server/src/fb.css
+++ b/server/src/fb.css
@@ -28,8 +28,12 @@ html {
 }
 
 ._1enh {
-    min-width: 280px;
-    width: 280px !important;
+    min-width: 320px;
+    width: 320px !important;
+}
+
+._1htf {
+    display:block;
 }
 
 ._5irm {


### PR DESCRIPTION
Due to chat summary now being 320px wide (previous width was 280px) and also due to some differences between flex / -webkit-box-flex CSS classes.

No idea why on Safari is pulling down CSS with "flex" but on WKWebView it's pulling down -webkit-box ¯\_(ツ)_/¯