### PR TITLE
Bypassing Facebook passthrough link for links which are outside of the Facebook domain

### DIFF
--- a/Goofy/AppDelegate.swift
+++ b/Goofy/AppDelegate.swift
@@ -147,8 +147,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKUIDe
                     // If such is the case...
                     if facebookFormattedLink {
                         do {
-                            // Generate a NSRegularExpression to match our url, extracting the value of u= into it's
-                            // own regex group.
+                            // Generate a NSRegularExpression to match our url, extracting the value of u= into it own regex group.
                             let regex = try NSRegularExpression(pattern: "(https://l.messenger.com/l.php\\?u=)(.+)(&h=.+)", options: [])
                             let nsString = url.absoluteString as NSString
                             let results = regex.firstMatchInString(url.absoluteString, options: [], range: NSMakeRange(0, nsString.length))


### PR DESCRIPTION
In the case that this is a link that has been formatted to l.messenger.com (IE, facebook warns us that we are leaving facebook through a link), extract the URL and direct the user to it directly instead of the 2 step facebook passthrough process

For issue #150