### PR TITLE
Adding a menu item and action to report an issue; opens to the github…

### DIFF
--- a/Goofy/Base.lproj/MainMenu.xib
+++ b/Goofy/Base.lproj/MainMenu.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="8191" systemVersion="14E46" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
     </dependencies>
@@ -409,6 +409,12 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
                         <items>
+                            <menuItem title="Report Issue" id="Mtt-0o-acG">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="reportIssue:" target="XE1-by-mZK" id="tCC-jz-oar"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Goofy Help" keyEquivalent="?" id="FKE-Sm-Kum">
                                 <connections>
                                     <action selector="showHelp:" target="-1" id="y7X-2Q-9no"/>
@@ -424,7 +430,7 @@
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="706" height="467"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3200" height="1777"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <view key="contentView" wantsLayer="YES" id="5iU-zi-Msx">
                 <rect key="frame" x="0.0" y="0.0" width="706" height="467"/>
                 <autoresizingMask key="autoresizingMask"/>

--- a/Goofy/MenuHandler.swift
+++ b/Goofy/MenuHandler.swift
@@ -78,6 +78,11 @@ class MenuHandler: NSObject {
         }
     }
     
+    @IBAction func reportIssue(sender: NSMenuItem) {
+        let reportIssueURL = NSURL(string: "https://github.com/danielbuechele/goofy/issues/new")
+        NSWorkspace.sharedWorkspace().openURL(reportIssueURL!)
+    }
+    
     @IBAction func sendImage(sender: NSMenuItem?) {
         let openPanel = NSOpenPanel()
         openPanel.allowsMultipleSelection = false


### PR DESCRIPTION
Added an option under the Help menu for 'Report Issue' which directs to to https://github.com/danielbuechele/goofy/issues/new

In the case that the user is not signed in, it will bring them to the log in page which will in turn send them to the report issue page.  It might be better to setup an email address dedicated for reporting issues so it's not ostracizing non-github users.

Recommended in issue https://github.com/danielbuechele/goofy/issues/136