### PR TITLE
Changed frown emoji

### DIFF
--- a/server/src/fb.js
+++ b/server/src/fb.js
@@ -254,7 +254,7 @@ function convertEmoji() {
 
 var EMOJI_TABLE = {
     "emoticon_smile": "😊",
-    "emoticon_frown": "😦",
+    "emoticon_frown": "😞",
     "emoticon_tongue": "😛",
     "emoticon_grin": "😀",
     "emoticon_gasp": "😦",


### PR DESCRIPTION
Replaced :( with [😞](http://emojipedia.org/disappointed-face/). 😞 is a better option and is what Facebook uses in their iOS apps.