### PR TITLE
Fix replying in notification sometimes not working

### DIFF
--- a/Goofy/NotificationScriptMessageHandler.swift
+++ b/Goofy/NotificationScriptMessageHandler.swift
@@ -88,7 +88,7 @@ class NotificationScriptMessageHandler: NSObject, WKScriptMessageHandler, NSUser
         let appDelegate = NSApplication.sharedApplication().delegate as! AppDelegate;
         let id = notification.userInfo!["id"] as! String
         if (notification.activationType == NSUserNotificationActivationType.Replied){
-            let userResponse = notification.response?.string;
+            let userResponse = notification.response?.string.stringByReplacingOccurrencesOfString("\n", withString: "\\n");
             appDelegate.webView.evaluateJavaScript("replyToNotification('" + id + "','" + userResponse! + "')", completionHandler: nil);
         } else {
             appDelegate.webView.evaluateJavaScript("reactivation('" + id + "')", completionHandler: nil);


### PR DESCRIPTION
If the reply contains multiple lines, the "\n" causes JS to be evaluated breaken into multiple lines, causing it to silently fail. This fixes it by escaping the newline.

This might be a fix to #240.