### PR TITLE
fixes #235, #162

### DIFF
--- a/Goofy/AppDelegate.swift
+++ b/Goofy/AppDelegate.swift
@@ -172,8 +172,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKUIDe
     func initWindow(window: NSWindow) {
         window.backgroundColor = NSColor.whiteColor()
         window.minSize = NSSize(width: 380,height: 376)
-        window.makeMainWindow()
-        window.makeKeyWindow()
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .Hidden
         window.delegate = self

--- a/Goofy/Info.plist
+++ b/Goofy/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>962</string>
+	<string>973</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.social-networking</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Allows Goofy to successfully run as a login item.

Judging by the console messages, Goofy was trying to acquire focus before actually being focusable. Given that the window is focused if launched anyways, this preserves the old behavior while addressing #235 and #162.

P.S. I am totally new to OS X development, so I'm not sure why Xcode changed CFBundleVersion. Please let me know if I've done something wrong 🙇 