### PR TITLE
fixes #261

### DIFF
--- a/Goofy/Info.plist
+++ b/Goofy/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>973</string>
+	<string>984</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.social-networking</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Goofy/TitleLabel.swift
+++ b/Goofy/TitleLabel.swift
@@ -27,7 +27,7 @@ class TitleLabel: NSViewController {
         activeLabel?.selectable = false
         activeLabel?.drawsBackground = false
         activeLabel?.alignment = .Center
-        activeLabel?.font = NSFont(name: "HelveticaNeue", size: 10.0)
+        activeLabel?.font = NSFont.systemFontOfSize(10.0)
         self.view.addSubview(activeLabel!)
         
         titleLabel = NSTextField(frame: CGRectMake(40, 0, self.view.frame.width, 36))
@@ -38,7 +38,7 @@ class TitleLabel: NSViewController {
         titleLabel?.drawsBackground = false
         titleLabel?.alignment = .Center
         titleLabel?.textColor = NSColor.blackColor()
-        titleLabel?.font = NSFont(name: "HelveticaNeue", size: 14.0)
+        titleLabel?.font = NSFont.systemFontOfSize(14.0)
         self.view.addSubview(titleLabel!)
         
         

--- a/server/src/fb.css
+++ b/server/src/fb.css
@@ -2,6 +2,11 @@ html {
     overflow: hidden;
 }
 
+body, button, input, label, select, td, textarea {
+    font-family: system, -apple-system, BlinkMacSystemFont,
+                 "Helvetica Neue", "Lucida Grande" !important;
+}
+
 /* weird display of input bar above messages, fixes #148*/
 ._4_j4 {
     display: block;


### PR DESCRIPTION
CSS and TitleLabel changed to use system font (San Francisco).

Methods for [CSS](http://furbo.org/2015/07/09/i-left-my-system-fonts-in-san-francisco/) and [TitleLabel](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSFont_Class/index.html#//apple_ref/occ/clm/NSFont/systemFontOfSize:) linked.