### PR TITLE
Fix crash when opening HTTP links

### DIFF
--- a/Goofy/AppDelegate.swift
+++ b/Goofy/AppDelegate.swift
@@ -128,7 +128,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKUIDe
                     if facebookFormattedLink {
                         do {
                             // Generate a NSRegularExpression to match our url, extracting the value of u= into it own regex group.
-                            let regex = try NSRegularExpression(pattern: "(https://l.messenger.com/l.php\\?u=)(.+)(&h=.+)", options: [])
+                            let regex = try NSRegularExpression(pattern: "(https?://l.messenger.com/l.php\\?u=)(.+)(&h=.+)", options: [])
                             let nsString = url.absoluteString! as NSString
                             let results = regex.firstMatchInString(url.absoluteString!, options: [], range: NSMakeRange(0, nsString.length))
 


### PR DESCRIPTION
Messenger.com now wraps http links with the http://l.messenger.com prefix (instead of using https for all links). The regex handling outbound links has been changed to match this.