### PR TITLE
Update README to reference macOS instead of OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Goofy
-Goofy is a OS X client for Facebook Messenger. But unlike most other clients, it does not use any of Facebook's APIs, but is basically a single-site browser that injects a little CSS and JS into [`messenger.com`](https://www.messenger.com/) to make it a little more app-like.
+Goofy is a macOS client for Facebook Messenger. But unlike most other clients, it does not use any of Facebook's APIs, but is basically a single-site browser that injects a little CSS and JS into [`messenger.com`](https://www.messenger.com/) to make it a little more app-like.
 
 ## Feature requests and contributing
 Feel free to create issues on this repo for feature requests of any kind. However, some features may not be possible due to the way this application is working. Also, I don't want this to be a feature bloated monster, but a slick and small app.


### PR DESCRIPTION
OS X was renamed to macOS (Sierra) in the latest version :)