### PR TITLE
Added link to goofy-core submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 Goofy is a macOS client for Facebook Messenger. But unlike most other clients, it does not use any of Facebook's APIs, but is basically a single-site browser that injects a little CSS and JS into [`messenger.com`](https://www.messenger.com/) to make it a little more app-like.
 
 ## Feature requests and contributing
-Feel free to create issues on this repo for feature requests of any kind. However, some features may not be possible due to the way this application is working. Also, I don't want this to be a feature bloated monster, but a slick and small app.
+Feel free to create issues on this repo for feature requests of any kind. However, some features may not be possible due to the way this application is working. Also, I don't want this to be a feature bloated monster, but a slick and small app. Goofy uses [goofy-core](https://github.com/danielbuechele/goofy-core) as a submodule.
 
 Depending on the number of contributors and the progress of this app, I will schedule releases from time to time, which will then be distributed on [`goofyapp.com`](http://www.goofyapp.com/) and via Sparkle.


### PR DESCRIPTION
When searching for commits or trying to understand code I kept searching for this repo. A link in the readme helps a lot and clears up the relationship.