### PR TITLE
Ability to hide message body in notifications

### DIFF
--- a/app/src/assets/fb.js
+++ b/app/src/assets/fb.js
@@ -1,5 +1,6 @@
 const { ipcRenderer } = require('electron');
 const constants = require('../helpers/constants');
+const userConfig = require('../modules/userConfig');
 let latestMessages;
 
 const NEW_MESSAGE_BUTTON = '._1enh ._3lz9 ._30yy._2oc8';
@@ -130,9 +131,11 @@ function processNotifications() {
 
 					const muted = message.classList.contains(MUTED);
 
+					const showMessagePreview = userConfig.get(constants.SETTINGS_MESSAGE_PREVIEW);
+
 					if (!isMessageFromSelf && !muted) {
 						let notification = new Notification(name, {
-							body: messageBody,
+							body: showMessagePreview ? messageBody : '',
 							icon: image,
 							data: id,
 							silent: true,

--- a/app/src/helpers/constants.js
+++ b/app/src/helpers/constants.js
@@ -10,5 +10,5 @@ module.exports = {
 	PRODUCT_WORKPLACE: 'workplace',
 	PRODUCT_WWW: 'www',
 	SETTINGS_STORAGE: 'settings.json',
-	SETTINGS_MESSAGE_PREVIEW: 'messagePreview'
+	SETTINGS_MESSAGE_PREVIEW: 'messagePreview',
 };

--- a/app/src/helpers/constants.js
+++ b/app/src/helpers/constants.js
@@ -10,4 +10,5 @@ module.exports = {
 	PRODUCT_WORKPLACE: 'workplace',
 	PRODUCT_WWW: 'www',
 	SETTINGS_STORAGE: 'settings.json',
+	SETTINGS_MESSAGE_PREVIEW: 'messagePreview'
 };

--- a/app/src/modules/userConfig.js
+++ b/app/src/modules/userConfig.js
@@ -1,9 +1,10 @@
 // This module makes a singleton configuration instance available for all other modules
 
 const Config = require('electron-config');
+const constants = require('../helpers/constants');
 const userConfig = new Config();
 
 //Set default value
-userConfig.set('messagePreview', true);
+userConfig.set(constants.SETTINGS_MESSAGE_PREVIEW, true);
 
 module.exports = userConfig;

--- a/app/src/modules/userConfig.js
+++ b/app/src/modules/userConfig.js
@@ -3,4 +3,7 @@
 const Config = require('electron-config');
 const userConfig = new Config();
 
+//Set default value
+userConfig.set('messagePreview', true);
+
 module.exports = userConfig;

--- a/app/src/modules/userConfig.js
+++ b/app/src/modules/userConfig.js
@@ -6,7 +6,7 @@ const userConfig = new Config();
 
 //Set default value
 if (typeof userConfig.get(constants.SETTINGS_MESSAGE_PREVIEW) === 'undefined') {
-    userConfig.set(constants.SETTINGS_MESSAGE_PREVIEW, true);
+	userConfig.set(constants.SETTINGS_MESSAGE_PREVIEW, true);
 }
 
 module.exports = userConfig;

--- a/app/src/modules/userConfig.js
+++ b/app/src/modules/userConfig.js
@@ -5,6 +5,8 @@ const constants = require('../helpers/constants');
 const userConfig = new Config();
 
 //Set default value
-userConfig.set(constants.SETTINGS_MESSAGE_PREVIEW, true);
+if (typeof userConfig.get(constants.SETTINGS_MESSAGE_PREVIEW) === 'undefined') {
+    userConfig.set(constants.SETTINGS_MESSAGE_PREVIEW, true);
+}
 
 module.exports = userConfig;

--- a/app/src/renderer.js
+++ b/app/src/renderer.js
@@ -144,6 +144,42 @@ onload = () => {
 		});
 	}
 
+	menu.splice(
+		3,
+		0,
+		{
+			label: 'Notifications',
+			submenu: [
+                {
+                    label: 'Message Preview in Notification',
+                    type: 'checkbox',
+                    checked: userConfig.get('messagePreview'),
+                    click() {
+                        //Default to true by default
+                        const showMessagePreview = (typeof userConfig.get('messagePreview') !== 'undefined') ? userConfig.get('messagePreview') : true;
+                        userConfig.set('messagePreview', !showMessagePreview);
+                        console.log('this', this);
+                    }
+                },
+                {
+                    label: 'Test Notification',
+                    click() {
+                        const showMessagePreview = (typeof userConfig.get('messagePreview') !== 'undefined') ? userConfig.get('messagePreview') : true;
+                        const messageBody = showMessagePreview ? 'Test Notification!' : 'Hidden test notification.';
+
+                        console.log('creating notification!!!');
+                        new Notification('Goofy', {
+                            body: messageBody,
+                            // icon: image,
+                            // data: id,
+                            silent: true,
+                        });
+                    }
+                }
+			]
+		}
+	);
+
 	Menu.setApplicationMenu(Menu.buildFromTemplate(menu));
 
 	webview.addEventListener('did-stop-loading', () => {

--- a/app/src/renderer.js
+++ b/app/src/renderer.js
@@ -153,25 +153,20 @@ onload = () => {
                 {
                     label: 'Message Preview in Notification',
                     type: 'checkbox',
-                    checked: userConfig.get('messagePreview'),
+                    checked: userConfig.get(constants.SETTINGS_MESSAGE_PREVIEW),
                     click() {
                         //Default to true by default
-                        const showMessagePreview = (typeof userConfig.get('messagePreview') !== 'undefined') ? userConfig.get('messagePreview') : true;
-                        userConfig.set('messagePreview', !showMessagePreview);
-                        console.log('this', this);
+                        userConfig.set(constants.SETTINGS_MESSAGE_PREVIEW, !userConfig.get(constants.SETTINGS_MESSAGE_PREVIEW));
                     }
                 },
                 {
-                    label: 'Test Notification',
+                    label: 'Create Test Notification',
                     click() {
-                        const showMessagePreview = (typeof userConfig.get('messagePreview') !== 'undefined') ? userConfig.get('messagePreview') : true;
+                        const showMessagePreview = userConfig.get(constants.SETTINGS_MESSAGE_PREVIEW);
                         const messageBody = showMessagePreview ? 'Test Notification!' : 'Hidden test notification.';
 
-                        console.log('creating notification!!!');
                         new Notification('Goofy', {
                             body: messageBody,
-                            // icon: image,
-                            // data: id,
                             silent: true,
                         });
                     }

--- a/app/src/renderer.js
+++ b/app/src/renderer.js
@@ -144,36 +144,45 @@ onload = () => {
 		});
 	}
 
+	const notificationsMenu = {
+		label: 'Notifications',
+		submenu: [
+			{
+				label: 'Message Preview in Notification',
+				type: 'checkbox',
+				checked: userConfig.get(constants.SETTINGS_MESSAGE_PREVIEW),
+				click() {
+					//Default to true by default
+					userConfig.set(constants.SETTINGS_MESSAGE_PREVIEW, !userConfig.get(constants.SETTINGS_MESSAGE_PREVIEW));
+				}
+			}
+		]
+	};
+
 	menu.splice(
 		3,
 		0,
-		{
-			label: 'Notifications',
-			submenu: [
-                {
-                    label: 'Message Preview in Notification',
-                    type: 'checkbox',
-                    checked: userConfig.get(constants.SETTINGS_MESSAGE_PREVIEW),
-                    click() {
-                        //Default to true by default
-                        userConfig.set(constants.SETTINGS_MESSAGE_PREVIEW, !userConfig.get(constants.SETTINGS_MESSAGE_PREVIEW));
-                    }
-                },
-                {
-                    label: 'Create Test Notification',
-                    click() {
-                        const showMessagePreview = userConfig.get(constants.SETTINGS_MESSAGE_PREVIEW);
-                        const messageBody = showMessagePreview ? 'Test Notification!' : 'Hidden test notification.';
-
-                        new Notification('Goofy', {
-                            body: messageBody,
-                            silent: true,
-                        });
-                    }
-                }
-			]
-		}
+		notificationsMenu
 	);
+
+	if (env.name === 'development') {
+		notificationsMenu.submenu.push({
+			type: 'separator'
+		});
+
+		notificationsMenu.submenu.push({
+			label: 'Create Test Notification',
+			click() {
+				const showMessagePreview = userConfig.get(constants.SETTINGS_MESSAGE_PREVIEW);
+				const messageBody = showMessagePreview ? 'Test Notification!' : 'Hidden test notification.';
+
+				new Notification('Goofy', {
+					body: messageBody,
+					silent: true,
+				});
+			}
+		});
+	}
 
 	Menu.setApplicationMenu(Menu.buildFromTemplate(menu));
 

--- a/app/src/renderer.js
+++ b/app/src/renderer.js
@@ -154,9 +154,9 @@ onload = () => {
 				click() {
 					//Default to true by default
 					userConfig.set(constants.SETTINGS_MESSAGE_PREVIEW, !userConfig.get(constants.SETTINGS_MESSAGE_PREVIEW));
-				}
-			}
-		]
+				},
+			},
+		],
 	};
 
 	menu.splice(
@@ -167,7 +167,7 @@ onload = () => {
 
 	if (env.name === 'development') {
 		notificationsMenu.submenu.push({
-			type: 'separator'
+			type: 'separator',
 		});
 
 		notificationsMenu.submenu.push({
@@ -180,7 +180,7 @@ onload = () => {
 					body: messageBody,
 					silent: true,
 				});
-			}
+			},
 		});
 	}
 

--- a/app/src/renderer.js
+++ b/app/src/renderer.js
@@ -174,9 +174,9 @@ onload = () => {
 			label: 'Create Test Notification',
 			click() {
 				const showMessagePreview = userConfig.get(constants.SETTINGS_MESSAGE_PREVIEW);
-				const messageBody = showMessagePreview ? 'Test Notification!' : 'Hidden test notification.';
+				const messageBody = showMessagePreview ? 'Test Notification!' : '';
 
-				new Notification('Goofy', {
+				new Notification('Goofy Test Notification', {
 					body: messageBody,
 					silent: true,
 				});


### PR DESCRIPTION
- Notifications can now be configured (via "Notifications" menu) to not display message content.
- In development environment, test notifications can be sent via menu item in Notifications menu.
- New user config flag to control whether or not message preview is displayed. Defaults to true.

Similar to https://github.com/danielbuechele/goofy/pull/415 not trying to create feature bloat, but it's kinda a pain that notifications appear and I am unable to control anything about them. This is nice for me as I'm kinda privacy oriented, and would like to know about my messages and click into the app to see their contents.