### PR TITLE
Update version 3.4.0

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "goofy-core",
-  "version": "3.3.5",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
potential missing versioning.

I noticed in release v3.3.5, the version was updated in the file 'app/package-lock.json' but was not done so for version v3.4.0. went ahead and updated and PRing.